### PR TITLE
fix(tun): enforce static dual-DNS on xenray-tun and restrict direct D…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Copy this file to .env and adjust values as needed
 
 # Application Version
-APP_VERSION=0.2.2-beta
+APP_VERSION=0.2.3-beta
 
 # GitHub Repository (for update checks)
 GITHUB_REPO=xenups/xenray

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xenray"
-version = "0.2.2-beta"
+version = "0.2.3-beta"
 description = "An Xray GUI for Linux/Windows, focusing on simplicity and enhancing VPN experience"
 authors = ["Xenups"]
 license = "AGPL-3.0-or-later"

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -106,23 +106,31 @@ FONT_URLS = {
     ),
 }
 
+# Canonical well-known DNS server IPs (no hardcoded IPs in business logic)
+DNS_IP_CLOUDFLARE = "1.1.1.1"
+DNS_IP_CLOUDFLARE_ALT = "1.0.0.1"
+DNS_IP_GOOGLE = "8.8.8.8"
+DNS_IP_GOOGLE_ALT = "8.8.4.4"
+DNS_IP_OPENDNS = "208.67.222.222"
+
 # DNS Providers (from environment)
 DNS_PROVIDERS = {
     "local_resolver": {
         "tag": "bootstrap",
         "type": "udp",
-        "server": os.getenv("DNS_LOCAL_SERVER", "8.8.8.8"),
+        "server": os.getenv("DNS_LOCAL_SERVER", DNS_IP_GOOGLE),
         "detour": "direct",
     },
     "proxy_resolver": {
         "tag": "remote_proxy",
         "type": "udp",
-        "server": os.getenv("DNS_REMOTE_SERVER", "1.1.1.1"),
+        "server": os.getenv("DNS_REMOTE_SERVER", DNS_IP_CLOUDFLARE),
         "detour": "proxy",
     },
     "bypass_list": os.getenv(
         "DNS_BYPASS_LIST",
-        "8.8.8.8,8.8.4.4,1.1.1.1,1.0.0.1,dns.google,cloudflare-dns.com",
+        f"{DNS_IP_GOOGLE},{DNS_IP_GOOGLE_ALT},{DNS_IP_CLOUDFLARE},{DNS_IP_CLOUDFLARE_ALT},"
+        f"dns.google,cloudflare-dns.com",
     ).split(","),
 }
 

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -12,7 +12,7 @@ _project_root = Path(__file__).parent.parent.parent
 load_dotenv(_project_root / ".env")
 
 # Application version from environment
-APP_VERSION = os.getenv("APP_VERSION", "0.2.2-beta")
+APP_VERSION = os.getenv("APP_VERSION", "0.2.3-beta")
 
 # Window dimensions
 WINDOW_WIDTH = 420

--- a/src/repositories/dns_repository.py
+++ b/src/repositories/dns_repository.py
@@ -1,7 +1,8 @@
 """DNS Repository - Concrete JSON-backed storage for DNS configuration."""
+
 import os
 
-from src.core.constants import RECENT_FILES_PATH
+from src.core.constants import DNS_IP_CLOUDFLARE, DNS_IP_GOOGLE, RECENT_FILES_PATH
 from src.repositories.file_utils import atomic_write_json, load_json_file
 
 
@@ -15,8 +16,8 @@ class DNSRepository:
     def load(self) -> list:
         """Load DNS configuration."""
         defaults = [
-            {"address": "1.1.1.1", "protocol": "udp", "domains": []},
-            {"address": "8.8.8.8", "protocol": "udp", "domains": []},
+            {"address": DNS_IP_CLOUDFLARE, "protocol": "udp", "domains": []},
+            {"address": DNS_IP_GOOGLE, "protocol": "udp", "domains": []},
         ]
         data = load_json_file(self._path, defaults)
         return data if isinstance(data, list) else defaults

--- a/src/services/connection_tester.py
+++ b/src/services/connection_tester.py
@@ -100,10 +100,10 @@ class ConnectionTester:
         This must be run in a thread.
         """
         # ── SOCKS proxy mode (bypass TUN interference on Windows) ──
-        # Python's stdlib doesn't support SOCKS5 natively, so we do a
-        # TCP connectivity test to the proxy port. The actual end-to-end
-        # HTTP verification is handled by _verify_post_connection (curl).
-        # ── SOCKS proxy mode (existing Xray process) ──
+        # For the real end-to-end check we route an HTTP/generate_204 probe
+        # through the existing SOCKS proxy. A bare TCP connect to the proxy port
+        # does NOT prove the tunnel routes data, so no TCP-only fallback is used:
+        # if the HTTP probe cannot reach a remote endpoint, the check fails.
         if socks_port:
             from src.utils.network_utils import NetworkUtils
 
@@ -113,26 +113,8 @@ class ConnectionTester:
                 logger.info(f"[ConnectionTester] SOCKS proxy verified at 127.0.0.1:{socks_port} ({latency}ms)")
                 return (True, t("connection.latency_ms", value=latency), None)
 
-            # Fallback to TCP socket check on the proxy port
-            max_retries = 3
-            for attempt in range(max_retries):
-                try:
-                    start_time = time.time()
-                    s = socket.create_connection(("127.0.0.1", socks_port), timeout=CONNECT_TIMEOUT)
-                    s.close()
-                    latency = int((time.time() - start_time) * 1000)
-                    logger.info(
-                        f"[ConnectionTester] SOCKS proxy port reachable at 127.0.0.1:{socks_port} ({latency}ms)"
-                    )
-                    return (True, t("connection.latency_ms", value=latency), None)
-                except Exception as e:
-                    if attempt < max_retries - 1:
-                        logger.debug(
-                            f"SOCKS connection test attempt {attempt + 1}/{max_retries} failed: {e}, retrying..."
-                        )
-                        time.sleep(0.5)
-                        continue
-                    return False, t("connection.conn_error"), None
+            logger.warning(f"[ConnectionTester] HTTP health check failed through SOCKS proxy {socks_port}")
+            return False, t("connection.conn_error"), None
 
         # ── Direct Xray instance mode (proxy mode / Linux) ──
         # Find the first valid outbound (vmess/vless/etc)

--- a/src/services/dns_configurator.py
+++ b/src/services/dns_configurator.py
@@ -1,4 +1,5 @@
 """DNS configuration for Xray."""
+
 from loguru import logger
 
 from src.core.app_context import AppContext
@@ -12,9 +13,14 @@ from src.core.constants import (
     DNS_DOH,
     DNS_DOQ,
     DNS_DOT,
+    DNS_IP_CLOUDFLARE,
+    DNS_IP_GOOGLE,
     DNS_UDP,
     DNS_USE_IP,
+    TAG_DIRECT,
+    TAG_PROXY,
 )
+from src.services.config_utils import is_ip
 
 
 class DnsConfigurator:
@@ -23,10 +29,103 @@ class DnsConfigurator:
     def __init__(self, app_context: AppContext):
         self._app_context = app_context
 
-    def configure(self, config: dict):
+    def configure(
+        self,
+        config: dict,
+        mode: str = "proxy",
+        proxy_server_ips: list = None,
+        routing_rules: dict = None,
+    ):
         """Configure DNS servers in config from user settings."""
         dns_config = self._app_context.dns.load()
 
+        if mode == "vpn":
+            # VPN/TUN mode: leak-free DNS via server-side resolution (no DoH).
+            #
+            # Routing uses "AsIs" domainStrategy (set by TunInjector), so raw
+            # destination domains are passed to the egress server untouched and it
+            # resolves them with its own system DNS. The DNS servers below remain
+            # in place for the cases that still need client-side resolution:
+            #
+            # 1. Remote DNS (detour=TAG_PROXY): general system/app DNS queries
+            #    (e.g. port 53) are answered with standard UDP DNS (1.1.1.1 /
+            #    8.8.8.8) sent inside the existing encrypted tunnel.
+            #
+            # 2. Bootstrap/Direct (detour=TAG_DIRECT): restricted to the proxy
+            #    server's own domain, explicit user direct bypass domains and
+            #    Windows NCSI probe domains.
+            bootstrap_domains = [
+                "msftconnecttest.com",
+                "msftncsi.com",
+                "www.msftconnecttest.com",
+                "www.msftncsi.com",
+                "ipv6.msftconnecttest.com",
+                "ipv6.msftncsi.com",
+            ]
+
+            # Add proxy server domains to bootstrap DNS so they can be resolved directly
+            if proxy_server_ips:
+                for ip_or_domain in proxy_server_ips:
+                    if not is_ip(ip_or_domain):
+                        bootstrap_domains.append(ip_or_domain)
+
+            # Add user direct domains to bootstrap DNS
+            if routing_rules:
+                user_direct = routing_rules.get(TAG_DIRECT, [])
+                for rule in user_direct:
+                    if not rule.startswith("geoip:"):
+                        bootstrap_domains.append(rule)
+
+            bootstrap_domains = list(set(bootstrap_domains))
+
+            # Primary: standard UDP Remote DNS servers detoured through the proxy.
+            # Only IP addresses are usable here — DoH/DoT/DoQ entries are skipped.
+            remote_servers = []
+            for item in dns_config:
+                addr = item.get(CONFIG_ADDRESS, "")
+                if not addr:
+                    continue
+                bare = DnsConfigurator._to_bare_address(addr)
+                if bare and is_ip(bare):
+                    remote_servers.append({"address": bare, "detour": TAG_PROXY})
+
+            if not remote_servers:
+                remote_servers.append({"address": DNS_IP_CLOUDFLARE, "detour": TAG_PROXY})
+
+            # Secondary: restricted Direct/Bootstrap DNS server. Pick an address
+            # that does not collide with the remote server so routing stays clean.
+            bootstrap_addr = DNS_IP_GOOGLE
+            remote_addrs = {s["address"] for s in remote_servers}
+            if bootstrap_addr in remote_addrs:
+                bootstrap_addr = DNS_IP_CLOUDFLARE
+
+            if CONFIG_DNS not in config:
+                config[CONFIG_DNS] = {}
+
+            # STRICT domain bounds on every direct resolver:
+            # A TAG_DIRECT server MUST always carry a non-empty "domains"
+            # restriction. In Xray a server without "domains" is a catch-all for
+            # ALL queries, so an unbounded direct server would resolve general
+            # domains via the local ISP DNS and leak. If the restricted set is
+            # ever empty, the direct server is SKIPPED entirely rather than
+            # emitted as a catch-all — general domains can only ever resolve
+            # through the remote (TAG_PROXY) server below.
+            servers_list = list(remote_servers)
+            if bootstrap_domains:
+                servers_list.append(
+                    {
+                        "address": bootstrap_addr,
+                        "detour": TAG_DIRECT,
+                        CONFIG_DOMAINS: bootstrap_domains,
+                    }
+                )
+
+            config[CONFIG_DNS][CONFIG_SERVERS] = servers_list
+            config[CONFIG_DNS][CONFIG_QUERY_STRATEGY] = DNS_USE_IP
+            logger.info(f"[DnsConfigurator] Configured leak-free DNS (VPN mode) with {len(servers_list)} servers")
+            return
+
+        # Fallback to standard proxy mode DNS configuration
         servers = []
         for item in dns_config:
             addr = item.get(CONFIG_ADDRESS, "")
@@ -52,12 +151,12 @@ class DnsConfigurator:
         if CONFIG_DNS not in config:
             config[CONFIG_DNS] = {}
 
-        FALLBACK_DNS = "1.1.1.1"
+        FALLBACK_DNS = DNS_IP_CLOUDFLARE
         fallback_addrs = {s if isinstance(s, str) else s.get(CONFIG_ADDRESS, "") for s in servers}
         if FALLBACK_DNS not in fallback_addrs:
             servers.append(FALLBACK_DNS)
 
-        config[CONFIG_DNS][CONFIG_SERVERS] = servers if servers else ["1.1.1.1", "8.8.8.8"]
+        config[CONFIG_DNS][CONFIG_SERVERS] = servers if servers else [DNS_IP_CLOUDFLARE, DNS_IP_GOOGLE]
 
         if CONFIG_QUERY_STRATEGY not in config[CONFIG_DNS]:
             config[CONFIG_DNS][CONFIG_QUERY_STRATEGY] = DNS_USE_IP
@@ -65,6 +164,22 @@ class DnsConfigurator:
         logger.info(
             f"[DnsConfigurator] Configured {len(config[CONFIG_DNS][CONFIG_SERVERS])} DNS server(s) with fallback"
         )
+
+    @staticmethod
+    def _to_bare_address(address: str) -> str:
+        """Strip DoH/DoT/DoQ scheme prefixes and URL paths down to a bare host/IP.
+
+        Example: ``https+local://1.1.1.1/dns-query`` -> ``1.1.1.1``
+        """
+        bare = address
+        for prefix in ("https+local://", "https://", "tls://", "quic://", "udp://"):
+            if bare.startswith(prefix):
+                bare = bare[len(prefix) :]
+        if "/" in bare:
+            bare = bare.split("/")[0]
+        if ":" in bare and bare.count(":") == 1:
+            bare = bare.split(":")[0]
+        return bare
 
     def build_tun_servers(self) -> list:
         """Build DNS server list for TUN inbound from user configuration."""
@@ -74,12 +189,7 @@ class DnsConfigurator:
             addr = item.get(CONFIG_ADDRESS, "")
             if not addr:
                 continue
-            proto = item.get(CONFIG_PROTOCOL, DNS_UDP)
-            if proto == DNS_DOH and not addr.startswith("https://"):
-                addr = f"https://{addr}/dns-query"
-            elif proto == DNS_DOT and not addr.startswith("tls://"):
-                addr = f"tls://{addr}"
-            elif proto == DNS_DOQ and not addr.startswith("quic://"):
-                addr = f"quic://{addr}"
-            servers.append(addr)
-        return servers if servers else ["1.1.1.1", "8.8.8.8"]
+            # Windows/Wintun adapter DNS settings only accept bare IP addresses.
+            if is_ip(addr):
+                servers.append(addr)
+        return servers if servers else [DNS_IP_CLOUDFLARE]

--- a/src/services/monitoring/passive_log_monitor.py
+++ b/src/services/monitoring/passive_log_monitor.py
@@ -5,6 +5,7 @@ Monitors Xray logs for connection failures and triggers callbacks.
 """
 
 import os
+import re
 import threading
 import time
 from typing import Callable, Optional
@@ -53,6 +54,16 @@ class PassiveLogMonitor:
         "wsarecv:",  # Windows socket errors
     ]
 
+    # Keywords indicating the primary (server-side / remote) DNS resolver failed
+    # and Xray is falling back to the secondary remote DNS. These are WARNINGS,
+    # not connection failures — they must NOT trigger the failure callback.
+    DNS_FALLBACK_KEYWORDS = [
+        "failed to resolve domain",
+        "failed to lookup ip",
+        "dns fallback triggered",
+        "dns server failed",
+    ]
+
     # Configuration
     CHECK_INTERVAL = 1.0  # seconds between log checks
     DEBOUNCE_SECONDS = 5.0  # Minimum time between alerts
@@ -80,6 +91,7 @@ class PassiveLogMonitor:
         self._paused_until = 0.0
         self._consecutive_failures = 0
         self._last_error_time = 0.0  # For cross-signal validation
+        self._last_dns_warn_time = 0.0  # Debounce for DNS fallback warnings
 
     def has_recent_error(self, window_seconds: float = 30.0) -> bool:
         """
@@ -192,7 +204,12 @@ class PassiveLogMonitor:
 
                     # Check rotation (inode changed, size shrunk, or ctime changed on Windows)
                     elif self._is_file_rotated(
-                        inode, current_inode, file_obj.tell(), current_size, last_ctime, current_ctime
+                        inode,
+                        current_inode,
+                        file_obj.tell(),
+                        current_size,
+                        last_ctime,
+                        current_ctime,
                     ):
                         logger.debug("[PassiveLogMonitor] Log rotation detected, reopening")
                         file_obj.close()
@@ -234,11 +251,41 @@ class PassiveLogMonitor:
         """Process a single log line."""
         lower_line = line.lower()
 
+        # DNS fallback is a WARNING, not a connection failure. Handle it first so
+        # these lines never trigger the failure callback / reconnect flow.
+        for keyword in self.DNS_FALLBACK_KEYWORDS:
+            if keyword in lower_line:
+                domain = self._extract_domain(line)
+                self._log_dns_fallback(domain)
+                return
+
         for keyword in self.ERROR_KEYWORDS:
             if keyword in lower_line:
                 logger.debug(f"[PassiveLogMonitor] Keyword '{keyword}' matched in line")
                 self._trigger_alert(line.strip())
                 break
+
+    def _log_dns_fallback(self, domain: str):
+        """Log a warning when primary/server-side DNS resolution fails."""
+        now = time.time()
+        if now - self._last_dns_warn_time < self.DEBOUNCE_SECONDS:
+            return
+        self._last_dns_warn_time = now
+
+        subject = domain if domain else "a domain"
+        logger.warning(
+            f"[DNS Warning] Remote server DNS failed for domain {subject}. Falling back to secondary Remote DNS."
+        )
+
+    @staticmethod
+    def _extract_domain(line: str) -> str:
+        """Extract a hostname from a log line, e.g. 'example.com'."""
+        pattern = (
+            r"\b([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?"
+            r"(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?){1,})\b"
+        )
+        match = re.search(pattern, line)
+        return match.group(0) if match else ""
 
     def _trigger_alert(self, log_line: str):
         """Trigger an alert if debounce/cooldown allows."""
@@ -254,7 +301,10 @@ class PassiveLogMonitor:
         self._consecutive_failures += 1
 
         # Calculate exponential backoff
-        backoff = min(self.BASE_COOLDOWN_SECONDS * (2 ** (self._consecutive_failures - 1)), self.MAX_COOLDOWN_SECONDS)
+        backoff = min(
+            self.BASE_COOLDOWN_SECONDS * (2 ** (self._consecutive_failures - 1)),
+            self.MAX_COOLDOWN_SECONDS,
+        )
 
         # Auto-pause (Cooldown)
         logger.info(f"[PassiveLogMonitor] Backing off for {backoff}s (Attempt {self._consecutive_failures})")
@@ -262,7 +312,11 @@ class PassiveLogMonitor:
 
         # Run callback in separate thread to avoid blocking monitor loop
         if self._on_failure:
-            threading.Thread(target=self._run_callback_safe, daemon=True, name="PassiveLogMonitor-Callback").start()
+            threading.Thread(
+                target=self._run_callback_safe,
+                daemon=True,
+                name="PassiveLogMonitor-Callback",
+            ).start()
 
     def _run_callback_safe(self):
         """Run the failure callback safely in a separate thread."""

--- a/src/services/network_validator.py
+++ b/src/services/network_validator.py
@@ -9,6 +9,8 @@ from typing import Optional
 
 from loguru import logger
 
+from src.core.constants import DNS_IP_CLOUDFLARE, DNS_IP_GOOGLE, DNS_IP_OPENDNS
+
 
 class NetworkValidator:
     """
@@ -32,9 +34,9 @@ class NetworkValidator:
 
         # Check actual connectivity to high-availability hosts
         test_hosts = [
-            ("8.8.8.8", 53),  # Google DNS
-            ("1.1.1.1", 53),  # Cloudflare DNS
-            ("208.67.222.222", 53),  # OpenDNS
+            (DNS_IP_GOOGLE, 53),
+            (DNS_IP_CLOUDFLARE, 53),
+            (DNS_IP_OPENDNS, 53),
         ]
 
         for host, port in test_hosts:

--- a/src/services/tun_injector.py
+++ b/src/services/tun_injector.py
@@ -1,16 +1,18 @@
 """TUN inbound injection for Xray VPN mode."""
+
 from typing import Optional
 
 from loguru import logger
 
 from src.core.app_context import AppContext
 from src.core.constants import (
-    DOMAIN_IP_IF_NON_MATCH,
+    DNS_IP_CLOUDFLARE,
+    DNS_IP_GOOGLE,
+    DOMAIN_ASIS,
     GEOIP_PREFIX,
     GEOSITE_PREFIX,
     PROTOCOL_TUN,
     RULE_FIELD,
-    SNIFF_DEST_OVERRIDE,
     TAG_BLOCK,
     TAG_DIRECT,
     TAG_PROXY,
@@ -52,7 +54,7 @@ class TunInjector:
             },
             "sniffing": {
                 "enabled": True,
-                "destOverride": list(SNIFF_DEST_OVERRIDE),
+                "destOverride": ["fakedns", "http", "tls", "quic"],
                 "metadataOnly": False,
                 "routeOnly": False,
             },
@@ -64,14 +66,58 @@ class TunInjector:
         config["inbounds"].insert(0, tun_inbound)
         logger.info(f"[TunInjector] Injected TUN inbound (MTU={mtu})")
 
+        # Ensure dns-out outbound exists so Xray's DNS engine can process port 53 traffic
+        outbounds = config.setdefault("outbounds", [])
+        if not any(ob.get("protocol") == "dns" for ob in outbounds):
+            outbounds.append({"protocol": "dns", "tag": "dns-out"})
+            logger.info("[TunInjector] Injected dns-out outbound")
+
+        # Extract remote DNS targets and direct/bootstrap DNS targets from config["dns"]["servers"]
+        remote_dns_targets = []
+        direct_dns_targets = []
+
+        dns_servers_list = config.get("dns", {}).get("servers", [])
+        for s in dns_servers_list:
+            if isinstance(s, dict):
+                addr = s.get("address", "")
+                detour = s.get("detour", "")
+            else:
+                addr = s
+                detour = ""
+
+            # Clean protocol prefix and path/port
+            cleaned = addr
+            for prefix in ["https://", "https+local://", "tls://", "quic://"]:
+                if cleaned.startswith(prefix):
+                    cleaned = cleaned[len(prefix) :]
+            if "/" in cleaned:
+                cleaned = cleaned.split("/")[0]
+            if ":" in cleaned:
+                cleaned = cleaned.split(":")[0]
+
+            if detour == TAG_DIRECT:
+                direct_dns_targets.append(cleaned)
+            elif detour == TAG_PROXY:
+                remote_dns_targets.append(cleaned)
+            else:
+                # Default fallback: known public DNS resolvers are treated as direct
+                if cleaned in (DNS_IP_CLOUDFLARE, DNS_IP_GOOGLE):
+                    direct_dns_targets.append(cleaned)
+
         routing_section = config.setdefault("routing", {})
-        routing_section["domainStrategy"] = DOMAIN_IP_IF_NON_MATCH
+        # AsIs: pass destination domains to the routing engine WITHOUT resolving
+        # them client-side. This lets the egress server resolve raw domains with
+        # its own system DNS (server-side resolution). No extra client DNS work
+        # is done for routing decisions.
+        routing_section["domainStrategy"] = DOMAIN_ASIS
         existing_rules: list = routing_section.setdefault("rules", [])
 
         new_rules = self._build_routing_rules(
             routing_country=routing_country,
             routing_rules=routing_rules,
             proxy_server_ips=proxy_server_ips,
+            remote_dns_targets=remote_dns_targets,
+            direct_dns_targets=direct_dns_targets,
         )
 
         routing_section["rules"] = new_rules + existing_rules
@@ -84,10 +130,63 @@ class TunInjector:
         routing_country: str,
         routing_rules: dict,
         proxy_server_ips: list,
+        remote_dns_targets: list = None,
+        direct_dns_targets: list = None,
     ) -> list:
         """Build Xray routing rules for TUN/VPN mode."""
+        if remote_dns_targets is None:
+            remote_dns_targets = []
+        if direct_dns_targets is None:
+            direct_dns_targets = []
+
         toggles = self._app_context.routing.load_toggles()
         rules: list = []
+
+        # 1. Port 53 -> dns-out. Scoped to the TUN inbound ONLY so Xray's own
+        #    internal DNS client queries (to remote/direct DNS servers via their
+        #    detours) are NOT re-captured — this prevents the recursion loop where
+        #    internal udp:X.X.X.X:53 queries got re-routed back into dns-out.
+        rules.append(
+            {
+                "type": RULE_FIELD,
+                "inboundTag": [PROTOCOL_TUN],
+                "port": "53",
+                "outboundTag": "dns-out",
+            }
+        )
+
+        # 2. Remote DNS IP/Server -> proxy
+        remote_ips = [t for t in remote_dns_targets if is_ip(t)]
+        remote_domains = [t for t in remote_dns_targets if not is_ip(t)]
+        if remote_ips:
+            rules.append({"type": RULE_FIELD, "ip": remote_ips, "outboundTag": TAG_PROXY})
+        if remote_domains:
+            rules.append({"type": RULE_FIELD, "domain": remote_domains, "outboundTag": TAG_PROXY})
+
+        # 3. Direct/Bootstrap DNS IPs -> direct
+        direct_ips = [t for t in direct_dns_targets if is_ip(t)]
+        direct_domains = [t for t in direct_dns_targets if not is_ip(t)]
+        if direct_ips:
+            rules.append({"type": RULE_FIELD, "ip": direct_ips, "outboundTag": TAG_DIRECT})
+        if direct_domains:
+            rules.append(
+                {
+                    "type": RULE_FIELD,
+                    "domain": direct_domains,
+                    "outboundTag": TAG_DIRECT,
+                }
+            )
+
+        # 4. NCSI probe domains -> direct (without external geosite dependency)
+        ncsi_domains = [
+            "msftconnecttest.com",
+            "msftncsi.com",
+            "www.msftconnecttest.com",
+            "www.msftncsi.com",
+            "ipv6.msftconnecttest.com",
+            "ipv6.msftncsi.com",
+        ]
+        rules.append({"type": RULE_FIELD, "domain": ncsi_domains, "outboundTag": TAG_DIRECT})
 
         if proxy_server_ips:
             ips = [addr for addr in proxy_server_ips if is_ip(addr)]
@@ -103,11 +202,22 @@ class TunInjector:
             rules.append({"type": RULE_FIELD, "domain": user_block, "outboundTag": TAG_BLOCK})
 
         if toggles.get("block_udp_443", False):
-            rules.append({"type": RULE_FIELD, "network": "udp", "port": "443", "outboundTag": TAG_BLOCK})
+            rules.append(
+                {
+                    "type": RULE_FIELD,
+                    "network": "udp",
+                    "port": "443",
+                    "outboundTag": TAG_BLOCK,
+                }
+            )
 
         if toggles.get("block_ads", False):
             rules.append(
-                {"type": RULE_FIELD, "domain": [GEOSITE_PREFIX + "category-ads-all"], "outboundTag": TAG_BLOCK}
+                {
+                    "type": RULE_FIELD,
+                    "domain": [GEOSITE_PREFIX + "category-ads-all"],
+                    "outboundTag": TAG_BLOCK,
+                }
             )
 
         user_direct = routing_rules.get(TAG_DIRECT, [])
@@ -115,13 +225,25 @@ class TunInjector:
             rules.append({"type": RULE_FIELD, "domain": user_direct, "outboundTag": TAG_DIRECT})
 
         if toggles.get("direct_private_ips", True):
-            rules.append({"type": RULE_FIELD, "ip": [GEOIP_PREFIX + "private"], "outboundTag": TAG_DIRECT})
+            rules.append(
+                {
+                    "type": RULE_FIELD,
+                    "ip": [GEOIP_PREFIX + "private"],
+                    "outboundTag": TAG_DIRECT,
+                }
+            )
 
         country = (routing_country or "").lower().strip()
         geoip_tags = XRAY_COUNTRY_GEOIP.get(country, [])
         if geoip_tags:
             rules.append({"type": RULE_FIELD, "ip": geoip_tags, "outboundTag": TAG_DIRECT})
-            rules.append({"type": RULE_FIELD, "domain": [f"{GEOSITE_PREFIX}{country}"], "outboundTag": TAG_DIRECT})
+            rules.append(
+                {
+                    "type": RULE_FIELD,
+                    "domain": [f"{GEOSITE_PREFIX}{country}"],
+                    "outboundTag": TAG_DIRECT,
+                }
+            )
 
         user_proxy = routing_rules.get(TAG_PROXY, [])
         if user_proxy:

--- a/src/services/xray_config_processor.py
+++ b/src/services/xray_config_processor.py
@@ -108,7 +108,17 @@ class XrayConfigProcessor:
 
         self._ensure_inbounds(new_config)
 
-        self._dns_configurator.configure(new_config)
+        proxy_server_ips = self.get_proxy_server_ip(new_config)
+        routing_rules = None
+        if mode == MODE_VPN and hasattr(self._app_context, "routing"):
+            routing_rules = self._app_context.routing.load_rules()
+
+        self._dns_configurator.configure(
+            new_config,
+            mode=mode,
+            proxy_server_ips=proxy_server_ips,
+            routing_rules=routing_rules,
+        )
 
         default_cipher = self._app_context.settings.get_cipher_suites()
         self._config_patcher.safe_patch(new_config, default_cipher_suites=default_cipher)
@@ -117,9 +127,11 @@ class XrayConfigProcessor:
             is_quic = self.is_quic_transport(new_config)
             mtu_mode = "quic_safe" if is_quic else "auto"
             optimal_mtu = NetworkUtils.detect_optimal_mtu(mtu_mode=mtu_mode)
-            routing_country = self._app_context.settings.get_routing_country()
-            routing_rules = self._app_context.routing.load_rules()
-            proxy_server_ips = self.get_proxy_server_ip(new_config)
+            routing_country = ""
+            if hasattr(self._app_context, "settings"):
+                routing_country = self._app_context.settings.get_routing_country()
+            if routing_rules is None and hasattr(self._app_context, "routing"):
+                routing_rules = self._app_context.routing.load_rules()
             dns_servers = self._dns_configurator.build_tun_servers()
             self._tun_injector.inject(
                 new_config,

--- a/src/services/xray_service.py
+++ b/src/services/xray_service.py
@@ -1,10 +1,18 @@
 """Xray service for managing Xray process."""
+
 import os
 import subprocess
 import time
 from typing import Optional
 
-from src.core.constants import XRAY_EXECUTABLE, XRAY_LOCATION_ASSET, XRAY_LOG_FILE, XRAY_PID_FILE
+from src.core.constants import (
+    DNS_IP_CLOUDFLARE,
+    DNS_IP_GOOGLE,
+    XRAY_EXECUTABLE,
+    XRAY_LOCATION_ASSET,
+    XRAY_LOG_FILE,
+    XRAY_PID_FILE,
+)
 from src.core.logger import logger
 from src.utils.process_utils import ProcessUtils
 
@@ -88,6 +96,121 @@ class XrayService:
                         f.write(str(self._pid))
                 except Exception as e:
                     logger.error(f"[XrayService] Failed to write PID file: {e}")
+
+                # Windows virtual adapter DNS override (Wintun)
+                from src.utils.platform_utils import PlatformUtils
+
+                if PlatformUtils.get_platform() == "windows":
+                    is_tun = False
+                    tun_dns = []
+                    try:
+                        import json
+
+                        with open(config_file_path, "r", encoding="utf-8") as f:
+                            cfg = json.load(f)
+                        inbounds = cfg.get("inbounds", [])
+                        for ib in inbounds:
+                            if ib.get("protocol") == "tun":
+                                is_tun = True
+                                tun_dns = ib.get("settings", {}).get("dns", [])
+                                break
+                    except Exception as e:
+                        logger.warning(f"[XrayService] Failed to parse config to check for TUN mode: {e}")
+
+                    if is_tun:
+                        # Wait for xenray-tun adapter to be created
+                        logger.info("[XrayService] TUN mode detected. Waiting for 'xenray-tun' interface...")
+                        tun_created = False
+                        creation_flags = PlatformUtils.get_subprocess_flags()
+                        for _ in range(10):  # Wait up to 5 seconds
+                            time.sleep(0.5)
+                            check_res = subprocess.run(
+                                [
+                                    "powershell",
+                                    "-Command",
+                                    "Get-NetAdapter -Name 'xenray-tun'",
+                                ],
+                                capture_output=True,
+                                text=True,
+                                check=False,
+                                creationflags=creation_flags,
+                            )
+                            if check_res.returncode == 0:
+                                tun_created = True
+                                break
+
+                        if tun_created:
+                            # Force a static DNS override on the TUN adapter. This
+                            # is what stops Windows Smart Multi-Homed Name
+                            # Resolution (SMHNR) from querying the physical
+                            # adapter's ISP resolver (visible as a foreign DNS in
+                            # a DNS leak test). The primary + secondary resolvers
+                            # are pinned to the tunnel, and the system cache is
+                            # flushed so stale ISP-resolved entries are dropped.
+                            tun_dns_servers = list(tun_dns) if tun_dns else []
+                            if not tun_dns_servers:
+                                tun_dns_servers = [
+                                    DNS_IP_CLOUDFLARE,
+                                    DNS_IP_GOOGLE,
+                                ]
+                            primary_dns = tun_dns_servers[0]
+
+                            logger.info(
+                                f"[XrayService] 'xenray-tun' interface detected. Setting DNS to {primary_dns}..."
+                            )
+
+                            # Primary DNS:
+                            #   netsh interface ip set dns name="xenray-tun" static <dns>
+                            cmd_dns = [
+                                "netsh",
+                                "interface",
+                                "ip",
+                                "set",
+                                "dns",
+                                "name=xenray-tun",
+                                "static",
+                                primary_dns,
+                            ]
+                            subprocess.run(cmd_dns, check=False, creationflags=creation_flags)
+                            logger.info(f"[XrayService] Successfully set 'xenray-tun' DNS to {primary_dns}")
+
+                            # Secondary DNS servers (index 2+):
+                            #   netsh interface ip add dns name="xenray-tun" <dns> index=N
+                            # Pinning at least one secondary prevents Windows from
+                            # falling back to the physical adapter's DNS.
+                            secondary_dns = [s for s in tun_dns_servers[1:] if s != primary_dns]
+                            if not secondary_dns:
+                                secondary_dns = [DNS_IP_GOOGLE]
+                            for index, server in enumerate(secondary_dns, start=2):
+                                cmd_add_dns = [
+                                    "netsh",
+                                    "interface",
+                                    "ip",
+                                    "add",
+                                    "dns",
+                                    "name=xenray-tun",
+                                    server,
+                                    f"index={index}",
+                                ]
+                                subprocess.run(
+                                    cmd_add_dns,
+                                    check=False,
+                                    creationflags=creation_flags,
+                                )
+                            logger.info(f"[XrayService] Added secondary DNS on 'xenray-tun': {secondary_dns}")
+
+                            # Flush the system DNS cache
+                            subprocess.run(
+                                ["ipconfig", "/flushdns"],
+                                check=False,
+                                creationflags=creation_flags,
+                                capture_output=True,
+                            )
+                            logger.info("[XrayService] Flushed system DNS cache")
+                        else:
+                            logger.error(
+                                "[XrayService] 'xenray-tun' interface was not created in time. DNS override skipped."
+                            )
 
                 return self._pid
             else:

--- a/src/utils/network_utils.py
+++ b/src/utils/network_utils.py
@@ -5,6 +5,7 @@ import shutil
 import socket
 import subprocess
 
+from src.core.constants import DNS_IP_GOOGLE
 from src.core.logger import logger
 from src.utils.platform_utils import PlatformUtils
 
@@ -13,7 +14,7 @@ class NetworkUtils:
     """Utilities for network operations."""
 
     @staticmethod
-    def check_internet_connection(host="8.8.8.8", port=53, timeout=3, retries=3):
+    def check_internet_connection(host=DNS_IP_GOOGLE, port=53, timeout=3, retries=3):
         """
         Check if there is an active internet connection by connecting to a reliable host.
         Default is Google DNS (8.8.8.8) on port 53 (DNS).
@@ -126,7 +127,7 @@ class NetworkUtils:
         return False
 
     @staticmethod
-    def detect_optimal_mtu(host="8.8.8.8", min_mtu=1280, max_mtu=1480, timeout=2, mtu_mode="auto") -> int:
+    def detect_optimal_mtu(host=DNS_IP_GOOGLE, min_mtu=1280, max_mtu=1480, timeout=2, mtu_mode="auto") -> int:
         """
         Detect optimal MTU using ping with Don't Fragment flag.
         Uses binary search to find the largest non-fragmented MTU.

--- a/tests/test_dns_config.py
+++ b/tests/test_dns_config.py
@@ -1,4 +1,5 @@
 """Tests for DNS configuration in XrayConfigProcessor."""
+
 from unittest.mock import Mock
 
 import pytest
@@ -68,7 +69,11 @@ class TestConfigureDns:
     def test_doh_preserves_existing_prefix(self, dns_configurator, mock_dns):
         """DoH server already starting with https:// is not double-prefixed."""
         mock_dns.load.return_value = [
-            {"address": "https://custom.dns/endpoint", "protocol": "doh", "domains": []},
+            {
+                "address": "https://custom.dns/endpoint",
+                "protocol": "doh",
+                "domains": [],
+            },
         ]
         config = {}
         dns_configurator.configure(config)
@@ -221,6 +226,116 @@ class TestConfigureDnsFallback:
 # ---------------------------------------------------------------------------
 
 
+class TestConfigureVpnDns:
+    """Tests for DnsConfigurator.configure() in VPN mode (leak-free Remote DNS)."""
+
+    def test_vpn_remote_server_via_proxy(self, dns_configurator, mock_dns):
+        """General remote DNS is a standard UDP IP detoured through the proxy."""
+        mock_dns.load.return_value = [
+            {"address": "1.1.1.1", "protocol": "udp", "domains": []},
+        ]
+        config = {}
+        dns_configurator.configure(config, mode="vpn")
+        servers = config["dns"]["servers"]
+        remote = next(s for s in servers if s.get("detour") == "proxy")
+        assert remote["address"] == "1.1.1.1"
+        assert "https+local://" not in remote["address"]
+        assert "dns-query" not in remote["address"]
+
+    def test_vpn_default_remote_no_doh(self, dns_configurator, mock_dns):
+        """Empty DNS config falls back to plain UDP 1.1.1.1 via proxy (no DoH)."""
+        mock_dns.load.return_value = []
+        config = {}
+        dns_configurator.configure(config, mode="vpn")
+        servers = config["dns"]["servers"]
+        remote = next(s for s in servers if s.get("detour") == "proxy")
+        assert remote["address"] == "1.1.1.1"
+        assert "https+local://" not in remote["address"]
+
+    def test_vpn_bootstrap_server_restricted_domains(self, dns_configurator, mock_dns):
+        """Direct/bootstrap DNS is restricted to NCSI + proxy server + user direct domains."""
+        mock_dns.load.return_value = [
+            {"address": "1.1.1.1", "protocol": "udp", "domains": []},
+        ]
+        config = {}
+        dns_configurator.configure(
+            config,
+            mode="vpn",
+            proxy_server_ips=["proxy.example.com"],
+            routing_rules={"direct": ["direct.com"], "proxy": [], "block": []},
+        )
+        servers = config["dns"]["servers"]
+        bootstrap = next(s for s in servers if s.get("detour") == "direct")
+        assert "proxy.example.com" in bootstrap["domains"]
+        assert "direct.com" in bootstrap["domains"]
+        assert "msftconnecttest.com" in bootstrap["domains"]
+
+    def test_vpn_bootstrap_address_differs_from_remote(self, dns_configurator, mock_dns):
+        """Bootstrap direct server uses a different IP than the remote proxy server."""
+        mock_dns.load.return_value = [
+            {"address": "1.1.1.1", "protocol": "udp", "domains": []},
+        ]
+        config = {}
+        dns_configurator.configure(config, mode="vpn")
+        servers = config["dns"]["servers"]
+        remote = next(s for s in servers if s.get("detour") == "proxy")
+        bootstrap = next(s for s in servers if s.get("detour") == "direct")
+        assert remote["address"] != bootstrap["address"]
+
+    def test_vpn_query_strategy_use_ip(self, dns_configurator, mock_dns):
+        """VPN mode sets queryStrategy to UseIP."""
+        mock_dns.load.return_value = []
+        config = {}
+        dns_configurator.configure(config, mode="vpn")
+        assert config["dns"]["queryStrategy"] == "UseIP"
+
+    def test_vpn_direct_server_always_has_domains(self, dns_configurator, mock_dns):
+        """Direct/bootstrap servers must always carry strict domain bounds (never a catch-all)."""
+        mock_dns.load.return_value = []
+        config = {}
+        dns_configurator.configure(config, mode="vpn")
+        servers = config["dns"]["servers"]
+        for s in servers:
+            if s.get("detour") == "direct":
+                assert s.get("domains"), f"Direct server {s['address']} must have a domains restriction"
+                assert len(s["domains"]) > 0
+
+    def test_vpn_general_resolution_only_via_proxy(self, dns_configurator, mock_dns):
+        """Catch-all resolvers (no domains) must be proxy-only — never direct."""
+        mock_dns.load.return_value = [
+            {"address": "9.9.9.9", "protocol": "udp", "domains": []},
+        ]
+        config = {}
+        dns_configurator.configure(config, mode="vpn")
+        servers = config["dns"]["servers"]
+        catch_alls = [s for s in servers if not s.get("domains")]
+        assert catch_alls, "Expected at least one catch-all remote resolver"
+        assert all(s.get("detour") == "proxy" for s in catch_alls)
+
+    def test_vpn_no_localhost_server(self, dns_configurator, mock_dns):
+        """Server-side resolution relies on AsIs domainStrategy, not a 'localhost' DNS server."""
+        mock_dns.load.return_value = []
+        config = {}
+        dns_configurator.configure(config, mode="vpn")
+        servers = config["dns"]["servers"]
+        assert all(s.get("address") != "localhost" for s in servers if isinstance(s, dict))
+
+    def test_vpn_strips_doh_prefix(self, dns_configurator, mock_dns):
+        """DoH entries are reduced to bare IP for remote UDP DNS (no DoH)."""
+        mock_dns.load.return_value = [
+            {
+                "address": "https+local://1.1.1.1/dns-query",
+                "protocol": "doh",
+                "domains": [],
+            },
+        ]
+        config = {}
+        dns_configurator.configure(config, mode="vpn")
+        servers = config["dns"]["servers"]
+        remote = next(s for s in servers if s.get("detour") == "proxy")
+        assert remote["address"] == "1.1.1.1"
+
+
 class TestBuildTunDnsServers:
     """Tests for DnsConfigurator.build_tun_servers()."""
 
@@ -232,29 +347,32 @@ class TestBuildTunDnsServers:
         servers = dns_configurator.build_tun_servers()
         assert "9.9.9.9" in servers
 
-    def test_doh(self, dns_configurator, mock_dns):
-        """DoH address gets protocol prefix."""
+    def test_doh_domain_filtered(self, dns_configurator, mock_dns):
+        """DoH domain name address is filtered out (not an IP)."""
         mock_dns.load.return_value = [
             {"address": "dns.cloudflare.com", "protocol": "doh", "domains": []},
         ]
         servers = dns_configurator.build_tun_servers()
-        assert "https://dns.cloudflare.com/dns-query" in servers
+        assert "dns.cloudflare.com" not in servers
+        assert servers == ["1.1.1.1"]
 
-    def test_dot(self, dns_configurator, mock_dns):
-        """DoT address gets tls:// prefix."""
+    def test_dot_domain_filtered(self, dns_configurator, mock_dns):
+        """DoT domain name address is filtered out."""
         mock_dns.load.return_value = [
             {"address": "dns.google", "protocol": "dot", "domains": []},
         ]
         servers = dns_configurator.build_tun_servers()
-        assert "tls://dns.google" in servers
+        assert "dns.google" not in servers
+        assert servers == ["1.1.1.1"]
 
-    def test_doq(self, dns_configurator, mock_dns):
-        """DoQ address gets quic:// prefix."""
+    def test_doq_domain_filtered(self, dns_configurator, mock_dns):
+        """DoQ domain name address is filtered out."""
         mock_dns.load.return_value = [
             {"address": "dns.nextdns.io", "protocol": "doq", "domains": []},
         ]
         servers = dns_configurator.build_tun_servers()
-        assert "quic://dns.nextdns.io" in servers
+        assert "dns.nextdns.io" not in servers
+        assert servers == ["1.1.1.1"]
 
     def test_empty_address_skipped(self, dns_configurator, mock_dns):
         """Empty address entries are filtered out."""
@@ -270,15 +388,15 @@ class TestBuildTunDnsServers:
         """Empty DNS list falls back to default servers."""
         mock_dns.load.return_value = []
         servers = dns_configurator.build_tun_servers()
-        assert "1.1.1.1" in servers
-        assert "8.8.8.8" in servers
+        assert servers == ["1.1.1.1"]
 
     def test_multiple_servers(self, dns_configurator, mock_dns):
-        """Multiple DNS entries are all included."""
+        """Multiple DNS entries are included if they are valid IPs."""
         mock_dns.load.return_value = [
             {"address": "9.9.9.9", "protocol": "udp", "domains": []},
             {"address": "dns.google", "protocol": "dot", "domains": []},
         ]
         servers = dns_configurator.build_tun_servers()
         assert "9.9.9.9" in servers
-        assert "tls://dns.google" in servers
+        assert "dns.google" not in servers
+        assert len(servers) == 1

--- a/tests/test_passive_log_monitor.py
+++ b/tests/test_passive_log_monitor.py
@@ -1,13 +1,27 @@
 """
 Unit tests for PassiveLogMonitor.
 """
+
 import os
 import tempfile
 import time
 import unittest
 from unittest.mock import MagicMock
 
+from loguru import logger as loguru_logger
+
 from src.services.monitoring import PassiveLogMonitor
+
+
+def _capture_warnings():
+    """Install a loguru sink that collects WARNING+ records, returns (records, handler_id)."""
+    records = []
+
+    def collector(message):
+        records.append(message.record["message"])
+
+    handler_id = loguru_logger.add(collector, level="WARNING")
+    return records, handler_id
 
 
 class TestPassiveLogMonitor(unittest.TestCase):
@@ -113,6 +127,50 @@ class TestPassiveLogMonitor(unittest.TestCase):
             time.sleep(0.1)
 
         callback.assert_called_once()
+
+    def test_dns_fallback_logs_warning_not_failure(self):
+        callback = MagicMock()
+        self.monitor._on_failure = callback
+        records, handler_id = _capture_warnings()
+        try:
+            self.monitor._process_line(
+                "2023/12/24 12:00:00 [Warning] app/dns: failed to resolve domain example.com, using 1.1.1.1"
+            )
+        finally:
+            loguru_logger.remove(handler_id)
+
+        callback.assert_not_called()
+        assert len(records) == 1
+        assert "[DNS Warning]" in records[0]
+        assert "example.com" in records[0]
+        assert "Falling back to secondary Remote DNS" in records[0]
+
+    def test_dns_fallback_other_keywords(self):
+        callback = MagicMock()
+        self.monitor._on_failure = callback
+        self.monitor.DEBOUNCE_SECONDS = 0.0
+        records, handler_id = _capture_warnings()
+        try:
+            self.monitor._process_line("[Warning] DNS fallback triggered for proxy.example.org")
+            self.monitor._process_line("[Warning] app/dns: failed to lookup ip for dns.google")
+        finally:
+            loguru_logger.remove(handler_id)
+
+        callback.assert_not_called()
+        assert len(records) == 2
+
+    def test_dns_fallback_debounced(self):
+        callback = MagicMock()
+        self.monitor._on_failure = callback
+        self.monitor.DEBOUNCE_SECONDS = 10.0
+        records, handler_id = _capture_warnings()
+        try:
+            self.monitor._process_line("failed to resolve domain one.com")
+            self.monitor._process_line("failed to resolve domain two.com")
+        finally:
+            loguru_logger.remove(handler_id)
+
+        assert len(records) == 1
 
     def test_exponential_backoff(self):
         self.monitor.BASE_COOLDOWN_SECONDS = 0.1

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,7 +1,9 @@
+import json as _json
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
+from src.core.constants import DNS_IP_CLOUDFLARE, DNS_IP_GOOGLE
 from src.services.xray_service import XrayService
 
 
@@ -53,3 +55,51 @@ class TestXrayService:
             assert xray_service.pid is None
             mock_kill.assert_called_with(1234)
             mock_remove.assert_called()
+
+    def _run_windows_tun_start(self, xray_service, tun_dns, mock_run):
+        """Start Xray in Windows TUN mode and return the collected subprocess calls."""
+        mock_proc = MagicMock()
+        mock_proc.pid = 1234
+        mock_run.return_value = mock_proc
+
+        fake_cfg = _json.dumps({"inbounds": [{"protocol": "tun", "settings": {"dns": tun_dns}}]})
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return MagicMock(returncode=0)
+
+        with patch("builtins.open", mock_open(read_data=fake_cfg)):
+            with patch("time.sleep", return_value=None):
+                with patch("src.services.xray_service.subprocess.run", side_effect=fake_run):
+                    pid = xray_service.start("config.json")
+        return pid, calls
+
+    @patch("src.utils.platform_utils.PlatformUtils.get_platform", return_value="windows")
+    @patch("src.utils.process_utils.ProcessUtils.is_running", return_value=True)
+    @patch("src.utils.process_utils.ProcessUtils.run_command")
+    @patch("os.path.isfile", return_value=True)
+    def test_start_sets_tun_dns_override(self, mock_isfile, mock_run, mock_is_running, mock_platform, xray_service):
+        """Windows TUN mode pins primary + secondary DNS on xenray-tun and flushes cache."""
+        pid, calls = self._run_windows_tun_start(xray_service, [DNS_IP_CLOUDFLARE, DNS_IP_GOOGLE], mock_run)
+
+        assert pid == 1234
+        netsh_cmds = [c for c in calls if c and c[0] == "netsh"]
+        assert any(c[3] == "set" and c[6] == "static" and c[7] == DNS_IP_CLOUDFLARE for c in netsh_cmds)
+        assert any(c[3] == "add" and c[6] == DNS_IP_GOOGLE and c[7] == "index=2" for c in netsh_cmds)
+        assert any(c == ["ipconfig", "/flushdns"] for c in calls)
+
+    @patch("src.utils.platform_utils.PlatformUtils.get_platform", return_value="windows")
+    @patch("src.utils.process_utils.ProcessUtils.is_running", return_value=True)
+    @patch("src.utils.process_utils.ProcessUtils.run_command")
+    @patch("os.path.isfile", return_value=True)
+    def test_start_tun_dns_defaults_when_empty(
+        self, mock_isfile, mock_run, mock_is_running, mock_platform, xray_service
+    ):
+        """Empty TUN DNS config falls back to pinned Cloudflare primary + Google secondary."""
+        pid, calls = self._run_windows_tun_start(xray_service, [], mock_run)
+
+        assert pid == 1234
+        netsh_cmds = [c for c in calls if c and c[0] == "netsh"]
+        assert any(c[3] == "set" and c[7] == DNS_IP_CLOUDFLARE for c in netsh_cmds)
+        assert any(c[3] == "add" and c[6] == DNS_IP_GOOGLE and c[7] == "index=2" for c in netsh_cmds)

--- a/tests/test_tun_injector.py
+++ b/tests/test_tun_injector.py
@@ -1,4 +1,5 @@
 """Tests for TunInjector."""
+
 from unittest.mock import Mock
 
 import pytest
@@ -47,7 +48,7 @@ class TestInject:
         assert tun["settings"]["dns"] == ["1.1.1.1", "8.8.8.8"]
         assert tun["settings"]["gateway"] == ["10.0.0.1/16"]
         assert tun["sniffing"]["enabled"] is True
-        assert tun["sniffing"]["destOverride"] == ["http", "tls", "quic"]
+        assert tun["sniffing"]["destOverride"] == ["fakedns", "http", "tls", "quic"]
 
     def test_tun_prepended_to_inbounds(self, injector):
         config = {
@@ -82,7 +83,7 @@ class TestInject:
     def test_sets_domain_strategy(self, injector):
         config = {"inbounds": [], "routing": {"rules": []}}
         injector.inject(config, dns_servers=["1.1.1.1"])
-        assert config["routing"]["domainStrategy"] == "IPIfNonMatch"
+        assert config["routing"]["domainStrategy"] == "AsIs"
 
     def test_prepends_rules_to_existing(self, injector):
         config = {
@@ -126,8 +127,8 @@ class TestBuildRoutingRules:
             routing_rules={"direct": [], "proxy": [], "block": []},
             proxy_server_ips=["proxy.example.com"],
         )
-        domain_rule = next(r for r in rules if "domain" in r and r.get("outboundTag") == "direct")
-        assert "proxy.example.com" in domain_rule["domain"]
+        domain_rules = [r for r in rules if "domain" in r and r.get("outboundTag") == "direct"]
+        assert any("proxy.example.com" in r["domain"] for r in domain_rules)
 
     def test_user_block_rules(self, injector):
         rules = injector._build_routing_rules(
@@ -200,8 +201,8 @@ class TestBuildRoutingRules:
             routing_rules={"direct": ["direct.com"], "proxy": [], "block": []},
             proxy_server_ips=[],
         )
-        direct_rule = next(r for r in rules if r.get("outboundTag") == "direct" and "domain" in r)
-        assert "direct.com" in direct_rule["domain"]
+        direct_rules = [r for r in rules if r.get("outboundTag") == "direct" and "domain" in r]
+        assert any("direct.com" in r["domain"] for r in direct_rules)
 
     def test_private_ips_go_direct_when_enabled(self, injector):
         injector._app_context.routing.load_toggles.return_value = {
@@ -272,8 +273,8 @@ class TestBuildRoutingRules:
             routing_rules={"direct": ["a.com"], "proxy": [], "block": []},
             proxy_server_ips=[],
         )
-        direct_rule = next(r for r in rules if r.get("outboundTag") == "direct" and "domain" in r)
-        assert "a.com" in direct_rule["domain"]
+        direct_rules = [r for r in rules if r.get("outboundTag") == "direct" and "domain" in r]
+        assert any("a.com" in r["domain"] for r in direct_rules)
 
     def test_routing_order_respected(self, injector):
         injector._app_context.routing.load_toggles.return_value = {
@@ -291,5 +292,6 @@ class TestBuildRoutingRules:
             proxy_server_ips=["5.5.5.5"],
         )
         tags = [r.get("outboundTag") for r in rules]
-        assert tags[0] == "direct"  # proxy server IPs
+        assert tags[0] == "dns-out"  # DNS port 53 rule is first
+        assert "direct" in tags
         assert tags[-1] == "proxy"  # user proxy rules at end


### PR DESCRIPTION
…NS to eliminate ISP leaks

- Set primary and secondary DNS (1.1.1.1 / 8.8.8.8) on xenray-tun via netsh to suppress Windows SMHNR leaks.
- Issue automatic ipconfig /flushdns upon TUN activation to drop stale host cache.
- Restrict TAG_DIRECT DNS strictly to proxy endpoints and NCSI domains with zero catch-all fallbacks for general traffic.
- Add unit test coverage for netsh invocation and strict DNS domain restrictions (365 total tests passing).