### PR TITLE
fix(tun): eliminate DNS leak via NRPT rule and enforce proxy DNS routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Copy this file to .env and adjust values as needed
 
 # Application Version
-APP_VERSION=0.2.3-beta
+APP_VERSION=0.2.4-beta
 
 # GitHub Repository (for update checks)
 GITHUB_REPO=xenups/xenray

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xenray"
-version = "0.2.3-beta"
+version = "0.2.4-beta"
 description = "An Xray GUI for Linux/Windows, focusing on simplicity and enhancing VPN experience"
 authors = ["Xenups"]
 license = "AGPL-3.0-or-later"

--- a/src/cli.py
+++ b/src/cli.py
@@ -192,6 +192,10 @@ def disconnect():
 
     typer.echo("🔄 Disconnecting...")
     conn_mgr.disconnect()
+    try:
+        conn_mgr.cleanup()
+    except Exception:
+        pass
     typer.echo("✅ Disconnected")
 
 

--- a/src/core/connection_manager.py
+++ b/src/core/connection_manager.py
@@ -238,6 +238,12 @@ class ConnectionManager:
         self._emit_event("disconnected")
         return True
 
+    def cleanup(self):
+        """Cleanup connection resources on exit."""
+        self.disconnect()
+        # Explicitly teardown connection with empty dict to force service stop and NRPT rule cleanup
+        self._orchestrator.teardown_connection({})
+
     def set_reconnect_event_listener(self, callback):
         """
         Set a callback to be notified of connection state changes.

--- a/src/core/connection_orchestrator.py
+++ b/src/core/connection_orchestrator.py
@@ -143,9 +143,8 @@ class ConnectionOrchestrator:
         NOTE: Monitoring is stopped by ConnectionManager via ConnectionMonitoringService
               before this method is called.
         """
-        # Stop Xray (single process — handles both proxy and TUN)
-        if connection_info.get("xray_pid"):
-            self._xray_service.stop()
+        # Always call stop to ensure Xray process is stopped and NRPT/DNS settings are cleaned up
+        self._xray_service.stop()
 
         logger.info("Connection torn down successfully")
 

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -12,7 +12,7 @@ _project_root = Path(__file__).parent.parent.parent
 load_dotenv(_project_root / ".env")
 
 # Application version from environment
-APP_VERSION = os.getenv("APP_VERSION", "0.2.3-beta")
+APP_VERSION = os.getenv("APP_VERSION", "0.2.4-beta")
 
 # Window dimensions
 WINDOW_WIDTH = 420

--- a/src/services/xray_service.py
+++ b/src/services/xray_service.py
@@ -53,7 +53,9 @@ class XrayService:
             cmd_remove = [
                 "powershell",
                 "-Command",
-                "Get-DnsClientNrptRule | Where-Object { $_.Namespace -eq '.' -and $_.Comment -like '*XenRay*' } | Remove-DnsClientNrptRule -Force",
+                "Get-DnsClientNrptRule | "
+                "Where-Object { $_.Namespace -eq '.' -and $_.Comment -like '*XenRay*' } | "
+                "Remove-DnsClientNrptRule -Force",
             ]
             subprocess.run(cmd_remove, check=False, creationflags=creation_flags)
 
@@ -181,7 +183,8 @@ class XrayService:
         cmd_nrpt = [
             "powershell",
             "-Command",
-            f"Add-DnsClientNrptRule -Namespace '.' -NameServers '{primary_dns}' -Comment 'XenRay TUN DNS'",
+            f"Add-DnsClientNrptRule -Namespace '.' -NameServers '{primary_dns}' "
+            "-Comment 'XenRay TUN DNS'",
         ]
         subprocess.run(cmd_nrpt, check=False, creationflags=creation_flags)
 

--- a/src/services/xray_service.py
+++ b/src/services/xray_service.py
@@ -43,6 +43,20 @@ class XrayService:
             except Exception:
                 pass
 
+    def _remove_nrpt_rules(self):
+        """Remove any XenRay NRPT DNS rules to restore system DNS."""
+        from src.utils.platform_utils import PlatformUtils
+
+        if PlatformUtils.get_platform() == "windows":
+            logger.info("[XrayService] Removing XenRay NRPT DNS rules...")
+            creation_flags = PlatformUtils.get_subprocess_flags()
+            cmd_remove = [
+                "powershell",
+                "-Command",
+                "Get-DnsClientNrptRule | Where-Object { $_.Namespace -eq '.' -and $_.Comment -like '*XenRay*' } | Remove-DnsClientNrptRule -Force",
+            ]
+            subprocess.run(cmd_remove, check=False, creationflags=creation_flags)
+
     def _cleanup_previous_instance(self):
         """Check for and kill any previous instance using PID file."""
         if os.path.exists(XRAY_PID_FILE):
@@ -57,6 +71,128 @@ class XrayService:
                 os.remove(XRAY_PID_FILE)
             except Exception as e:
                 logger.warning(f"[XrayService] Failed to cleanup old PID file: {e}")
+
+        # Always remove NRPT rules to clean up system state
+        self._remove_nrpt_rules()
+
+    def _configure_windows_tun_dns(self, config_file_path: str):
+        """Configure DNS and NRPT settings for the virtual TUN adapter on Windows."""
+        from src.utils.platform_utils import PlatformUtils
+
+        if PlatformUtils.get_platform() != "windows":
+            return
+
+        is_tun = False
+        tun_dns = []
+        try:
+            import json
+
+            with open(config_file_path, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+            inbounds = cfg.get("inbounds", [])
+            for ib in inbounds:
+                if ib.get("protocol") == "tun":
+                    is_tun = True
+                    tun_dns = ib.get("settings", {}).get("dns", [])
+                    break
+        except Exception as e:
+            logger.warning(f"[XrayService] Failed to parse config to check for TUN mode: {e}")
+            return
+
+        if not is_tun:
+            return
+
+        # Wait for xenray-tun adapter to be created
+        logger.info("[XrayService] TUN mode detected. Waiting for 'xenray-tun' interface...")
+        tun_created = False
+        creation_flags = PlatformUtils.get_subprocess_flags()
+        for _ in range(10):  # Wait up to 5 seconds
+            time.sleep(0.5)
+            check_res = subprocess.run(
+                [
+                    "powershell",
+                    "-Command",
+                    "Get-NetAdapter -Name 'xenray-tun'",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                creationflags=creation_flags,
+            )
+            if check_res.returncode == 0:
+                tun_created = True
+                break
+
+        if not tun_created:
+            logger.error("[XrayService] 'xenray-tun' interface was not created in time. DNS override skipped.")
+            return
+
+        # Force a static DNS override on the TUN adapter.
+        tun_dns_servers = list(tun_dns) if tun_dns else []
+        if not tun_dns_servers:
+            tun_dns_servers = [
+                DNS_IP_CLOUDFLARE,
+                DNS_IP_GOOGLE,
+            ]
+        primary_dns = tun_dns_servers[0]
+
+        logger.info(f"[XrayService] 'xenray-tun' interface detected. Setting DNS to {primary_dns}...")
+
+        # Primary DNS:
+        #   netsh interface ip set dns name="xenray-tun" static <dns>
+        cmd_dns = [
+            "netsh",
+            "interface",
+            "ip",
+            "set",
+            "dns",
+            "name=xenray-tun",
+            "static",
+            primary_dns,
+        ]
+        subprocess.run(cmd_dns, check=False, creationflags=creation_flags)
+        logger.info(f"[XrayService] Successfully set 'xenray-tun' DNS to {primary_dns}")
+
+        # Secondary DNS servers (index 2+):
+        #   netsh interface ip add dns name="xenray-tun" <dns> index=N
+        secondary_dns = [s for s in tun_dns_servers[1:] if s != primary_dns]
+        if not secondary_dns:
+            secondary_dns = [DNS_IP_GOOGLE]
+        for index, server in enumerate(secondary_dns, start=2):
+            cmd_add_dns = [
+                "netsh",
+                "interface",
+                "ip",
+                "add",
+                "dns",
+                "name=xenray-tun",
+                server,
+                f"index={index}",
+            ]
+            subprocess.run(
+                cmd_add_dns,
+                check=False,
+                creationflags=creation_flags,
+            )
+        logger.info(f"[XrayService] Added secondary DNS on 'xenray-tun': {secondary_dns}")
+
+        # Add NRPT rule to prevent DNS leaks by forcing all name resolution to the TUN DNS
+        logger.info(f"[XrayService] Adding NRPT rule for namespace '.' pointing to {primary_dns}...")
+        cmd_nrpt = [
+            "powershell",
+            "-Command",
+            f"Add-DnsClientNrptRule -Namespace '.' -NameServers '{primary_dns}' -Comment 'XenRay TUN DNS'",
+        ]
+        subprocess.run(cmd_nrpt, check=False, creationflags=creation_flags)
+
+        # Flush the system DNS cache
+        subprocess.run(
+            ["ipconfig", "/flushdns"],
+            check=False,
+            creationflags=creation_flags,
+            capture_output=True,
+        )
+        logger.info("[XrayService] Flushed system DNS cache")
 
     def start(self, config_file_path: str) -> Optional[int]:
         """
@@ -98,119 +234,7 @@ class XrayService:
                     logger.error(f"[XrayService] Failed to write PID file: {e}")
 
                 # Windows virtual adapter DNS override (Wintun)
-                from src.utils.platform_utils import PlatformUtils
-
-                if PlatformUtils.get_platform() == "windows":
-                    is_tun = False
-                    tun_dns = []
-                    try:
-                        import json
-
-                        with open(config_file_path, "r", encoding="utf-8") as f:
-                            cfg = json.load(f)
-                        inbounds = cfg.get("inbounds", [])
-                        for ib in inbounds:
-                            if ib.get("protocol") == "tun":
-                                is_tun = True
-                                tun_dns = ib.get("settings", {}).get("dns", [])
-                                break
-                    except Exception as e:
-                        logger.warning(f"[XrayService] Failed to parse config to check for TUN mode: {e}")
-
-                    if is_tun:
-                        # Wait for xenray-tun adapter to be created
-                        logger.info("[XrayService] TUN mode detected. Waiting for 'xenray-tun' interface...")
-                        tun_created = False
-                        creation_flags = PlatformUtils.get_subprocess_flags()
-                        for _ in range(10):  # Wait up to 5 seconds
-                            time.sleep(0.5)
-                            check_res = subprocess.run(
-                                [
-                                    "powershell",
-                                    "-Command",
-                                    "Get-NetAdapter -Name 'xenray-tun'",
-                                ],
-                                capture_output=True,
-                                text=True,
-                                check=False,
-                                creationflags=creation_flags,
-                            )
-                            if check_res.returncode == 0:
-                                tun_created = True
-                                break
-
-                        if tun_created:
-                            # Force a static DNS override on the TUN adapter. This
-                            # is what stops Windows Smart Multi-Homed Name
-                            # Resolution (SMHNR) from querying the physical
-                            # adapter's ISP resolver (visible as a foreign DNS in
-                            # a DNS leak test). The primary + secondary resolvers
-                            # are pinned to the tunnel, and the system cache is
-                            # flushed so stale ISP-resolved entries are dropped.
-                            tun_dns_servers = list(tun_dns) if tun_dns else []
-                            if not tun_dns_servers:
-                                tun_dns_servers = [
-                                    DNS_IP_CLOUDFLARE,
-                                    DNS_IP_GOOGLE,
-                                ]
-                            primary_dns = tun_dns_servers[0]
-
-                            logger.info(
-                                f"[XrayService] 'xenray-tun' interface detected. Setting DNS to {primary_dns}..."
-                            )
-
-                            # Primary DNS:
-                            #   netsh interface ip set dns name="xenray-tun" static <dns>
-                            cmd_dns = [
-                                "netsh",
-                                "interface",
-                                "ip",
-                                "set",
-                                "dns",
-                                "name=xenray-tun",
-                                "static",
-                                primary_dns,
-                            ]
-                            subprocess.run(cmd_dns, check=False, creationflags=creation_flags)
-                            logger.info(f"[XrayService] Successfully set 'xenray-tun' DNS to {primary_dns}")
-
-                            # Secondary DNS servers (index 2+):
-                            #   netsh interface ip add dns name="xenray-tun" <dns> index=N
-                            # Pinning at least one secondary prevents Windows from
-                            # falling back to the physical adapter's DNS.
-                            secondary_dns = [s for s in tun_dns_servers[1:] if s != primary_dns]
-                            if not secondary_dns:
-                                secondary_dns = [DNS_IP_GOOGLE]
-                            for index, server in enumerate(secondary_dns, start=2):
-                                cmd_add_dns = [
-                                    "netsh",
-                                    "interface",
-                                    "ip",
-                                    "add",
-                                    "dns",
-                                    "name=xenray-tun",
-                                    server,
-                                    f"index={index}",
-                                ]
-                                subprocess.run(
-                                    cmd_add_dns,
-                                    check=False,
-                                    creationflags=creation_flags,
-                                )
-                            logger.info(f"[XrayService] Added secondary DNS on 'xenray-tun': {secondary_dns}")
-
-                            # Flush the system DNS cache
-                            subprocess.run(
-                                ["ipconfig", "/flushdns"],
-                                check=False,
-                                creationflags=creation_flags,
-                                capture_output=True,
-                            )
-                            logger.info("[XrayService] Flushed system DNS cache")
-                        else:
-                            logger.error(
-                                "[XrayService] 'xenray-tun' interface was not created in time. DNS override skipped."
-                            )
+                self._configure_windows_tun_dns(config_file_path)
 
                 return self._pid
             else:
@@ -224,6 +248,9 @@ class XrayService:
         """
         Stop Xray process.
         """
+        # Always remove NRPT rules to clean up system state on stop
+        self._remove_nrpt_rules()
+
         # Checks memory PID first
         pid_to_kill = self._pid
 

--- a/src/services/xray_service.py
+++ b/src/services/xray_service.py
@@ -183,8 +183,7 @@ class XrayService:
         cmd_nrpt = [
             "powershell",
             "-Command",
-            f"Add-DnsClientNrptRule -Namespace '.' -NameServers '{primary_dns}' "
-            "-Comment 'XenRay TUN DNS'",
+            f"Add-DnsClientNrptRule -Namespace '.' -NameServers '{primary_dns}' " "-Comment 'XenRay TUN DNS'",
         ]
         subprocess.run(cmd_nrpt, check=False, creationflags=creation_flags)
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -527,7 +527,7 @@ class MainWindow:
         except Exception:
             pass
         try:
-            self._connection_manager.disconnect()
+            self._connection_manager.cleanup()
         except Exception:
             pass
         try:


### PR DESCRIPTION
- Add global NRPT wildcard rule (`Add-DnsClientNrptRule -Namespace '.'`) to completely block Windows SMHNR leaks.
- Ensure strict lifecycle cleanup for NRPT rules on app stop, pre-flight, UI close, and CLI disconnect.
- Route primary remote DNS queries through proxy detour (`TAG_PROXY`) with `AsIs` domain strategy.
- Restrict direct bootstrap resolvers exclusively to proxy endpoints and NCSI domains.
- Pin static DNS to virtual `xenray-tun` adapter via netsh while leaving physical adapters untouched.